### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,5 +58,5 @@ dependencies {
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
+    implementation "com.google.android.gms:play-services-auth:20.4.0"
 }


### PR DESCRIPTION
currently using com.google.android.gms.auth.api version is depricated and throwing this error.

java:15: error: package com.google.android.gms.auth.api.identity does not exist
import com.google.android.gms.auth.api.identity.GetPhoneNumberHintIntentRequest;

I have updated it with version 20.4.0, please review it and merge or do the required update